### PR TITLE
fix: tickplay track been selected instead of the real one

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1573,7 +1573,7 @@ class ReactExoplayerView extends FrameLayout implements
     private int getBitrateForHeight(int height) {
         final int[] foundBitrate = {0}; // converting int into final int[] with single item to bypass lambda
         loopThroughTracks(C.TRACK_TYPE_VIDEO, format -> {
-            if (format.height == height) {
+            if (format.height == height && format.bitrate > foundBitrate[0]) {
                 foundBitrate[0] = format.bitrate;
             }
             return null;


### PR DESCRIPTION
on some hls streams where it has a trickplay track, the selected bitrate was the trickplay one not the actual track
now fixed by finding the highest bitrate for the selected height 