### PR TITLE
feat: adding error cause to youbora error reporting

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/CustomAdapter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/CustomAdapter.java
@@ -1,5 +1,4 @@
 package com.brentvatne.exoplayer;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import com.brentvatne.exoplayer.ReactExoplayerView;


### PR DESCRIPTION
Adding native exoplayer error cause and message to youbora custom adapter
this change will add the error cause to the meta data, to make it more visible and understandable.